### PR TITLE
Add ProgressDialogDoWorkEventArgs extension (non-breaking)

### DIFF
--- a/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
@@ -22,6 +22,7 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
+using System.Threading;
 
 namespace Ookii.Dialogs.Wpf
 {
@@ -679,8 +680,19 @@ namespace Ookii.Dialogs.Wpf
         protected virtual void OnDoWork(DoWorkEventArgs e)
         {
             DoWorkEventHandler handler = DoWork;
-            if( handler != null )
-                handler(this, e);
+            if (!(handler is null))
+            {
+                var eventArgs = new ProgressDialogDoWorkEventArgs(e.Argument, CancellationToken.None)
+                {
+                    Cancel = e.Cancel,
+                    Result = e.Result,
+                };
+
+                handler(this, eventArgs);
+
+                e.Cancel = eventArgs.Cancel;
+                e.Result = eventArgs.Result;
+            }
         }
 
         /// <summary>

--- a/src/Ookii.Dialogs.Wpf/ProgressDialogDoWorkEventArgs.cs
+++ b/src/Ookii.Dialogs.Wpf/ProgressDialogDoWorkEventArgs.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel;
+using System.Threading;
+
+namespace Ookii.Dialogs.Wpf
+{
+    /// <summary>
+    /// Provides data for the System.ComponentModel.BackgroundWorker.DoWork event handler.
+    /// </summary>
+    public class ProgressDialogDoWorkEventArgs : DoWorkEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProgressDialogDoWorkEventArgs"/> class.
+        /// </summary>
+        /// <param name="argument">Specifies an argument for an asynchronous operation.</param>
+        /// <param name="cancellationToken">Specifies a cancellation token for an asynchronous operation.</param>
+        public ProgressDialogDoWorkEventArgs(object argument, CancellationToken cancellationToken)
+            : base(argument)
+        {
+            CancellationToken = cancellationToken;
+        }
+
+        /// <summary>
+        /// Gets a value that represents the CancellationToken of an asynchronous operation.
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
+    }
+}


### PR DESCRIPTION
PoC for https://github.com/ookii-dialogs/ookii-dialogs-wpf/pull/54

- Pros:
  - Allow a `CancellationToken` to flow through the `DoWork` event handler
  - Non-breaking change. Could be released with v3.2.0
- Cons:
  - User needs to cast  `DoWorkEventArgs` to `ProgressDialogDoWorkEventArgs` in order to access the `CancellationToken`

---

Relates to #53