### PR TITLE
Add ProgressDialogDoWorkEventArgs extension (breaking)

### DIFF
--- a/sample/Ookii.Dialogs.Wpf.Sample/MainWindow.xaml.cs
+++ b/sample/Ookii.Dialogs.Wpf.Sample/MainWindow.xaml.cs
@@ -36,7 +36,7 @@ namespace Ookii.Dialogs.Wpf.Sample
         {
             InitializeComponent();
 
-            _sampleProgressDialog.DoWork += new DoWorkEventHandler(_sampleProgressDialog_DoWork);
+            _sampleProgressDialog.DoWork += new ProgressDialogDoWorkEventHandler(_sampleProgressDialog_DoWork);
         }
 
 
@@ -199,7 +199,7 @@ namespace Ookii.Dialogs.Wpf.Sample
             System.Diagnostics.Process.Start(e.Href);
         }
 
-        private void _sampleProgressDialog_DoWork(object sender, DoWorkEventArgs e)
+        private void _sampleProgressDialog_DoWork(object sender, ProgressDialogDoWorkEventArgs e)
         {
             // Implement the operation that the progress bar is showing progress of here, same as you would do with a background worker.
             for( int x = 0; x <= 100; ++x )

--- a/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
@@ -22,6 +22,7 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Interop;
+using System.Threading;
 
 namespace Ookii.Dialogs.Wpf
 {
@@ -66,7 +67,7 @@ namespace Ookii.Dialogs.Wpf
         /// Use this event to perform the operation that the dialog is showing the progress for.
         /// This event will be raised on a different thread than the UI thread.
         /// </remarks>
-        public event DoWorkEventHandler DoWork;
+        public event ProgressDialogDoWorkEventHandler DoWork;
 
         /// <summary>
         /// Event raised when the operation completes.
@@ -678,9 +679,20 @@ namespace Ookii.Dialogs.Wpf
         /// <param name="e">The <see cref="DoWorkEventArgs"/> containing data for the event.</param>
         protected virtual void OnDoWork(DoWorkEventArgs e)
         {
-            DoWorkEventHandler handler = DoWork;
-            if( handler != null )
-                handler(this, e);
+            ProgressDialogDoWorkEventHandler handler = DoWork;
+            if (!(handler is null))
+            {
+                var eventArgs = new ProgressDialogDoWorkEventArgs(e.Argument, CancellationToken.None)
+                {
+                    Cancel = e.Cancel,
+                    Result = e.Result,
+                };
+
+                handler(this, eventArgs);
+
+                e.Cancel = eventArgs.Cancel;
+                e.Result = eventArgs.Result;
+            }
         }
 
         /// <summary>

--- a/src/Ookii.Dialogs.Wpf/ProgressDialogDoWorkEventArgs.cs
+++ b/src/Ookii.Dialogs.Wpf/ProgressDialogDoWorkEventArgs.cs
@@ -1,0 +1,27 @@
+﻿using System.ComponentModel;
+using System.Threading;
+
+namespace Ookii.Dialogs.Wpf
+{
+    /// <summary>
+    /// Provides data for the System.ComponentModel.BackgroundWorker.DoWork event handler.
+    /// </summary>
+    public class ProgressDialogDoWorkEventArgs : DoWorkEventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProgressDialogDoWorkEventArgs"/> class.
+        /// </summary>
+        /// <param name="argument">Specifies an argument for an asynchronous operation.</param>
+        /// <param name="cancellationToken">Specifies a cancellation token for an asynchronous operation.</param>
+        public ProgressDialogDoWorkEventArgs(object argument, CancellationToken cancellationToken)
+            : base(argument)
+        {
+            CancellationToken = cancellationToken;
+        }
+
+        /// <summary>
+        /// Gets a value that represents the CancellationToken of an asynchronous operation.
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
+    }
+}

--- a/src/Ookii.Dialogs.Wpf/ProgressDialogDoWorkEventHandler.cs
+++ b/src/Ookii.Dialogs.Wpf/ProgressDialogDoWorkEventHandler.cs
@@ -1,0 +1,10 @@
+﻿namespace Ookii.Dialogs.Wpf
+{
+    /// <summary>
+    /// Represents the method that will handle the <see cref="ProgressDialog.DoWork"/>
+    /// event. This class cannot be inherited.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="e">A <see cref="ProgressDialogDoWorkEventArgs"/> that contains the event data.</param>
+    public delegate void ProgressDialogDoWorkEventHandler(object sender, ProgressDialogDoWorkEventArgs e);
+}


### PR DESCRIPTION
PoC for https://github.com/ookii-dialogs/ookii-dialogs-wpf/pull/54

- Pros:
  - Allow a `CancellationToken` to flow through the `DoWork` event handler
  - No need for user cast  `DoWorkEventArgs` to `ProgressDialogDoWorkEventArgs` in order to access the `CancellationToken`
- Cons:
  - Breaking change. To be released with v4.0.0

---

Relates to #53