### PR TITLE
Use safe null operator since cancellation token source can be null at…

### DIFF
--- a/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
@@ -853,7 +853,7 @@ namespace Ookii.Dialogs.Wpf
 
             if (cancellationRequestedByUser && !cancellationRequestedByCode)
             {
-                cancellationTokenSource.Cancel();
+                cancellationTokenSource?.Cancel();
             }
 
             _cancellationPending = cancellationRequestedByUser || cancellationRequestedByCode;


### PR DESCRIPTION
#138 