### PR TITLE
Update CsWin32 version (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ The `Ookii.Dialogs.Wpf.VistaOpenFileDialog`, `Ookii.Dialogs.Wpf.VistaSaveFileDia
 
 The classes have been designed to resemble the original WPF classes to make it easy to switch. When the classes are used on Windows XP, they will automatically fall back to the old style dialog; this is also true for the `VistaFolderBrowserDialog`; that class provides a complete implementation of a folder browser dialog for WPF, old as well as new style.
 
-## .NET Core 3.1 & .NET 5 pre-requisites **before** Ookii.Dialogs.Wpf v3.1.0
+## .NET 5 pre-requisites **before** Ookii.Dialogs.Wpf v3.1.0
 
-> **NOTE: Starting with Ookii.Dialogs.Wpf v3.1.0 an app.manifest is no longer required when using in .NET 5 or .NET Core 3.1 apps**
+> **NOTE: Starting with Ookii.Dialogs.Wpf v3.1.0 an app.manifest is no longer required when using in .NET 5 apps**
 
-Ookii Dialogs leverages the components and visual styles of the Windows Common Controls library (`comctl32.dll`), and WPF applications targeting .NET Core 3.1 and/or .NET 5 must add an [application manifest](https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests) (`app.manifest`) to their projects with a reference to `Microsoft.Windows.Common-Controls`.
+Ookii Dialogs leverages the components and visual styles of the Windows Common Controls library (`comctl32.dll`), and WPF applications targeting .NET 5 must add an [application manifest](https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests) (`app.manifest`) to their projects with a reference to `Microsoft.Windows.Common-Controls`.
 
 Without the application manifest, you'll get an error with a message similar to the below:
 

--- a/sample/Ookii.Dialogs.Wpf.Sample/Ookii.Dialogs.Wpf.Sample.csproj
+++ b/sample/Ookii.Dialogs.Wpf.Sample/Ookii.Dialogs.Wpf.Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net5.0-windows;net462</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/Ookii.Dialogs.Wpf/AnimationResource.cs
+++ b/src/Ookii.Dialogs.Wpf/AnimationResource.cs
@@ -76,7 +76,7 @@ namespace Ookii.Dialogs.Wpf
 
         internal FreeLibrarySafeHandle LoadLibrary()
         {
-            var handle = NativeMethods.LoadLibraryEx(ResourceFile, default, Windows.Win32.System.LibraryLoader.LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_AS_DATAFILE);
+            var handle = NativeMethods.LoadLibraryEx(ResourceFile, Windows.Win32.System.LibraryLoader.LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_AS_DATAFILE);
             if( handle.IsInvalid )
             {
                 int error = System.Runtime.InteropServices.Marshal.GetLastWin32Error();

--- a/src/Ookii.Dialogs.Wpf/ComCtlv6ActivationContext.cs
+++ b/src/Ookii.Dialogs.Wpf/ComCtlv6ActivationContext.cs
@@ -25,7 +25,7 @@ namespace Ookii.Dialogs.Wpf
         // Private data
         private nuint _cookie;
         private static ACTCTXW _enableThemingActivationContext;
-        private static SafeFileHandle _activationContext;
+        private static ReleaseActCtxSafeHandle _activationContext;
         private static bool _contextCreationSucceeded;
         private static readonly object _contextCreationLock = new object();
 

--- a/src/Ookii.Dialogs.Wpf/CredentialDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/CredentialDialog.cs
@@ -674,7 +674,7 @@ namespace Ookii.Dialogs.Wpf
             if (cred != null)
                 return cred;
 
-            var result = NativeMethods.CredRead(target, (uint)CRED_TYPE.CRED_TYPE_GENERIC, 0, out var credential);
+            var result = NativeMethods.CredRead(target, (uint)CRED_TYPE.CRED_TYPE_GENERIC, out var credential);
             int error = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
             if (result)
             {
@@ -759,7 +759,7 @@ namespace Ookii.Dialogs.Wpf
                 found = _applicationInstanceCredentialCache.Remove(target);
             }
 
-            if (NativeMethods.CredDelete(target, (uint)CRED_TYPE.CRED_TYPE_GENERIC, 0))
+            if (NativeMethods.CredDelete(target, (uint)CRED_TYPE.CRED_TYPE_GENERIC))
             {
                 found = true;
             }
@@ -805,7 +805,7 @@ namespace Ookii.Dialogs.Wpf
             Password.AsSpan().CopyTo(pwSpan);
             WIN32_ERROR result;
             fixed (BOOL* b = &_isSaveChecked)
-                result = (WIN32_ERROR)NativeMethods.CredUIPromptForCredentials(info, Target, ref Unsafe.AsRef<SecHandle>((void*)0), 0, ref userSpan, NativeMethods.CREDUI_MAX_USERNAME_LENGTH, ref pwSpan, NativeMethods.CREDUI_MAX_PASSWORD_LENGTH, b, flags);
+                result = (WIN32_ERROR)NativeMethods.CredUIPromptForCredentials(info, Target, 0, ref userSpan, NativeMethods.CREDUI_MAX_USERNAME_LENGTH, ref pwSpan, NativeMethods.CREDUI_MAX_PASSWORD_LENGTH, b, flags);
 
             switch (result)
             {

--- a/src/Ookii.Dialogs.Wpf/Interop/Win32Resources.cs
+++ b/src/Ookii.Dialogs.Wpf/Interop/Win32Resources.cs
@@ -32,7 +32,7 @@ namespace Ookii.Dialogs.Wpf.Interop
 
         public Win32Resources(string module)
         {
-            _moduleHandle = NativeMethods.LoadLibraryEx(module, default, LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_AS_DATAFILE);
+            _moduleHandle = NativeMethods.LoadLibraryEx(module, LOAD_LIBRARY_FLAGS.LOAD_LIBRARY_AS_DATAFILE);
             if (_moduleHandle.IsInvalid)
                 throw new System.ComponentModel.Win32Exception(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
         }

--- a/src/Ookii.Dialogs.Wpf/Ookii.Dialogs.Wpf.csproj
+++ b/src/Ookii.Dialogs.Wpf/Ookii.Dialogs.Wpf.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net5.0-windows;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
     <RootNamespace>Ookii.Dialogs.Wpf</RootNamespace>
@@ -52,10 +52,6 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <DefineConstants>$(DefineConstants);NETFX</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <DefineConstants>$(DefineConstants);NETCORE31</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net5.0-windows' ">

--- a/src/Ookii.Dialogs.Wpf/Ookii.Dialogs.Wpf.csproj
+++ b/src/Ookii.Dialogs.Wpf/Ookii.Dialogs.Wpf.csproj
@@ -64,7 +64,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.63-beta" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.252-beta" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)'=='net462'" />
   </ItemGroup>
 

--- a/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/ProgressDialog.cs
@@ -149,7 +149,7 @@ namespace Ookii.Dialogs.Wpf
                 unsafe
                 {
                     if (_dialog != null)
-                        _dialog.SetLine(1, Text, UseCompactPathsForText, default);
+                        _dialog.SetLine(1, Text, UseCompactPathsForText);
                 }
             }
         }
@@ -181,7 +181,7 @@ namespace Ookii.Dialogs.Wpf
                 unsafe
                 {
                     if ( _dialog != null )
-                    _dialog.SetLine(1, Text, UseCompactPathsForText, default);
+                    _dialog.SetLine(1, Text, UseCompactPathsForText);
                 }
             }
         }
@@ -212,7 +212,7 @@ namespace Ookii.Dialogs.Wpf
                 unsafe
                 {
                     if (_dialog != null)
-                        _dialog.SetLine(2, Description, UseCompactPathsForDescription, default);
+                        _dialog.SetLine(2, Description, UseCompactPathsForDescription);
                 }
             }
         }
@@ -244,7 +244,7 @@ namespace Ookii.Dialogs.Wpf
                 unsafe
                 {
                     if (_dialog != null)
-                        _dialog.SetLine(2, Description, UseCompactPathsForDescription, default);
+                        _dialog.SetLine(2, Description, UseCompactPathsForDescription);
                 }
             }
         }
@@ -772,9 +772,9 @@ namespace Ookii.Dialogs.Wpf
                 _dialog.SetAnimation(_currentAnimationModuleHandle, (ushort)Animation.ResourceId);
 
             if( CancellationText.Length > 0 )
-                _dialog.SetCancelMsg(CancellationText, null);
-            _dialog.SetLine(1, Text, UseCompactPathsForText, default);
-            _dialog.SetLine(2, Description, UseCompactPathsForDescription, default);
+                _dialog.SetCancelMsg(CancellationText);
+            _dialog.SetLine(1, Text, UseCompactPathsForText);
+            _dialog.SetLine(2, Description, UseCompactPathsForDescription);
 
             uint flags = NativeMethods.PROGDLG_NORMAL;
             if( owner != IntPtr.Zero )

--- a/src/Ookii.Dialogs.Wpf/VistaFolderBrowserDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/VistaFolderBrowserDialog.cs
@@ -303,9 +303,10 @@ namespace Ookii.Dialogs.Wpf
         private unsafe bool RunDialogDownlevel(HWND owner)
         {
             IntPtr resultItemIdList = IntPtr.Zero;
-            if (NativeMethods.SHGetSpecialFolderLocation(owner, (int)RootFolder, out ITEMIDLIST* rootItemIdList) != HRESULT.S_OK)
+            ITEMIDLIST* rootItemIdList;
+            if (NativeMethods.SHGetSpecialFolderLocation(owner, (int)RootFolder, &rootItemIdList) != HRESULT.S_OK)
             {
-                if (NativeMethods.SHGetSpecialFolderLocation(owner, 0, out rootItemIdList) != 0)
+                if (NativeMethods.SHGetSpecialFolderLocation(owner, 0, &rootItemIdList) != 0)
                 {
                     throw new InvalidOperationException(Properties.Resources.FolderBrowserDialogNoRootFolder);
                 }

--- a/src/Ookii.Dialogs.Wpf/VistaOpenFileDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/VistaOpenFileDialog.cs
@@ -238,8 +238,7 @@ namespace Ookii.Dialogs.Wpf
             if( ShowReadOnly )
             {
                 IFileDialogCustomize customize = (IFileDialogCustomize)dialog;
-                uint selected;
-                customize.GetSelectedControlItem(_openDropDownId, &selected);
+                customize.GetSelectedControlItem(_openDropDownId, out var selected);
                 _readOnlyChecked = (selected == _readOnlyItemId);
             }
 

--- a/src/Ookii.Dialogs/Ookii.Dialogs.csproj
+++ b/src/Ookii.Dialogs/Ookii.Dialogs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net5.0-windows;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net5.0-windows;net462</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
 


### PR DESCRIPTION
Updated CsWin32 version and fixed various breaking changes. 

One of the things I ran into was that it seemed like .NET Core 3.1 no longer compiles in this project. It seems like 3.1 has a dependency on CompilerServices.Unsafe 4.x.x.x and CsWin32 now requires version 6.x.x.x. This was causing: 1. Conflicting version warnings in the 3.1 build. 2. Compile errors since version 4.x.x.x was a primary reference, it didn't support Unsafe.SkipInit. Since core 3.1 is out of support, I figured it would be easiest to just drop it since it was causing problems. I've also dealt with enough nuget versioning issues to know that this likely is a pain to solve.