### PR TITLE
`private` fields which are never re-assigned were made `readonly`

### DIFF
--- a/sample/Ookii.Dialogs.Wpf.Sample/MainWindow.xaml.cs
+++ b/sample/Ookii.Dialogs.Wpf.Sample/MainWindow.xaml.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using System;
-using System.Windows;
-using System.Threading;
 using System.ComponentModel;
+using System.Threading;
+using System.Windows;
 
 namespace Ookii.Dialogs.Wpf.Sample
 {
@@ -24,7 +24,7 @@ namespace Ookii.Dialogs.Wpf.Sample
     /// </summary>
     public partial class MainWindow : Window
     {
-        private ProgressDialog _sampleProgressDialog = new ProgressDialog()
+        private readonly ProgressDialog _sampleProgressDialog = new ProgressDialog()
             {
                 WindowTitle = "Progress dialog sample",
                 Text = "This is a sample progress dialog...",

--- a/src/Ookii.Dialogs.Wpf/CredentialDialog.cs
+++ b/src/Ookii.Dialogs.Wpf/CredentialDialog.cs
@@ -16,15 +16,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
-using System.Security.Permissions;
+using System.ComponentModel;
 using System.Net;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Permissions;
+using System.Text;
 using System.Windows;
 using System.Windows.Interop;
-using System.ComponentModel;
-using System.Runtime.CompilerServices;
 
 namespace Ookii.Dialogs.Wpf
 {
@@ -52,7 +51,7 @@ namespace Ookii.Dialogs.Wpf
     public partial class CredentialDialog : Component
     {
         private string _confirmTarget;
-        private NetworkCredential _credentials = new NetworkCredential();
+        private readonly NetworkCredential _credentials = new NetworkCredential();
         private byte[] _additionalEntropy;
         private BOOL _isSaveChecked;
         private string _target;

--- a/src/Ookii.Dialogs.Wpf/ExpandButtonClickedEventArgs.cs
+++ b/src/Ookii.Dialogs.Wpf/ExpandButtonClickedEventArgs.cs
@@ -15,8 +15,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ookii.Dialogs.Wpf
 {
@@ -26,7 +24,7 @@ namespace Ookii.Dialogs.Wpf
     /// <threadsafety instance="false" static="true" />
     public class ExpandButtonClickedEventArgs : EventArgs
     {
-        private bool _expanded;
+        private readonly bool _expanded;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExpandButtonClickedEventArgs"/> class with the specified expanded state.

--- a/src/Ookii.Dialogs.Wpf/HyperlinkClickedEventArgs.cs
+++ b/src/Ookii.Dialogs.Wpf/HyperlinkClickedEventArgs.cs
@@ -15,8 +15,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ookii.Dialogs.Wpf
 {
@@ -26,7 +24,7 @@ namespace Ookii.Dialogs.Wpf
     /// <threadsafety instance="false" static="true" />
     public class HyperlinkClickedEventArgs : EventArgs
     {
-        private string _href;
+        private readonly string _href;
 
         /// <summary>
         /// Creates a new instance of the <see cref="HyperlinkClickedEventArgs"/> class with the specified URL.

--- a/src/Ookii.Dialogs.Wpf/Interop/ComDlgResources.cs
+++ b/src/Ookii.Dialogs.Wpf/Interop/ComDlgResources.cs
@@ -28,7 +28,7 @@ namespace Ookii.Dialogs.Wpf.Interop
             ConfirmSaveAs = 435
         }
 
-        private static Win32Resources _resources = new Win32Resources("comdlg32.dll");
+        private static readonly Win32Resources _resources = new Win32Resources("comdlg32.dll");
 
         public static string LoadString(ComDlgResourceId id)
         {

--- a/src/Ookii.Dialogs.Wpf/Interop/Win32Resources.cs
+++ b/src/Ookii.Dialogs.Wpf/Interop/Win32Resources.cs
@@ -15,19 +15,16 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Text;
-using Windows.Win32;
 using Windows.Win32.System.Diagnostics.Debug;
 using Windows.Win32.System.LibraryLoader;
-using System.Runtime.CompilerServices;
 
 namespace Ookii.Dialogs.Wpf.Interop
 {
     class Win32Resources : IDisposable
     {
-        private SafeHandle _moduleHandle;
+        private readonly SafeHandle _moduleHandle;
         private const int _bufferSize = 500;
 
         public Win32Resources(string module)

--- a/src/Ookii.Dialogs.Wpf/TaskDialogItemCollection.cs
+++ b/src/Ookii.Dialogs.Wpf/TaskDialogItemCollection.cs
@@ -15,8 +15,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Collections.ObjectModel;
 
 namespace Ookii.Dialogs.Wpf
@@ -28,7 +26,7 @@ namespace Ookii.Dialogs.Wpf
     /// <threadsafety instance="false" static="true" />
     public class TaskDialogItemCollection<T> : Collection<T> where T : TaskDialogItem
     {
-        private TaskDialog _owner;
+        private readonly TaskDialog _owner;
 
         internal TaskDialogItemCollection(TaskDialog owner)
         {

--- a/src/Ookii.Dialogs.Wpf/TimerEventArgs.cs
+++ b/src/Ookii.Dialogs.Wpf/TimerEventArgs.cs
@@ -15,8 +15,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Ookii.Dialogs.Wpf
 {
@@ -26,7 +24,7 @@ namespace Ookii.Dialogs.Wpf
     /// <threadsafety instance="false" static="true" />
     public class TimerEventArgs : EventArgs
     {
-        private int _tickCount;
+        private readonly int _tickCount;
         private bool _resetTickCount;
 
         /// <summary>

--- a/src/Ookii.Dialogs.Wpf/VistaFileDialogEvents.cs
+++ b/src/Ookii.Dialogs.Wpf/VistaFileDialogEvents.cs
@@ -20,7 +20,7 @@ namespace Ookii.Dialogs.Wpf
 {
     class VistaFileDialogEvents : IFileDialogEvents, IFileDialogControlEvents
     {
-        private VistaFileDialog _dialog;
+        private readonly VistaFileDialog _dialog;
 
         public VistaFileDialogEvents(VistaFileDialog dialog)
         {


### PR DESCRIPTION
As an extra, I removed unused namespace references in the files that were touched by this change